### PR TITLE
fix: pull tags when updating tumor-evolution repo

### DIFF
--- a/actions/generate_tumor_evolution_report.sh
+++ b/actions/generate_tumor_evolution_report.sh
@@ -39,7 +39,7 @@ if [ $(docker images -q "${IMAGE}" | wc -l) -eq 0 ]; then
         git clone https://github.com/gmc-norr/tumor-evolution.git
     fi
     cd tumor-evolution
-    git pull origin main
+    git pull --tags origin main
     git checkout "v${VERSION}"
     docker build -t "${IMAGE}" .
     echo >&2 "INFO: docker image built"


### PR DESCRIPTION
This PR fixes an issue with the update of the tumor evolution repo where the tags weren't pulled from the remote, resulting in the checkout failing.