### PR TITLE
fix: fail if the report cannot be generated

### DIFF
--- a/actions/workflows/tumor_evolution.yaml
+++ b/actions/workflows/tumor_evolution.yaml
@@ -23,12 +23,13 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - log: <% result().stderr %>
-        # do: cleanup
         do: noop
       - when: <% failed() %>
         publish:
           - log: <% result().stderr %>
-        do: write_log
+        do: 
+          - write_log
+          - fail
 
   write_log:
     action: gmc_norr.write_file


### PR DESCRIPTION
Previously, if the report generation failed and the logging succeeded, the overall state was success. This forces the workflow to fail even if the logging is successful.